### PR TITLE
日本語化とデフォルト修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# codex2
+# 夢記録アプリ
+
+Flask と SQLite を使った簡単な夢の記録アプリです。
+
+## セットアップ
+
+1. （任意）仮想環境を作成します。
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+2. 依存パッケージをインストールします。
+
+```bash
+pip install -r requirements.txt
+```
+
+3. データベースを初期化します。
+
+```bash
+python -c "from app import db; db.create_all()"
+```
+
+## 実行方法
+
+開発サーバーを起動します。
+
+```bash
+python app.py
+```
+
+ブラウザで [http://localhost:5000](http://localhost:5000) を開くとアプリが利用できます。

--- a/app.py
+++ b/app.py
@@ -1,0 +1,56 @@
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime, date
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///dreams.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+
+db = SQLAlchemy(app)
+
+class Dream(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(100), nullable=False)
+    date = db.Column(db.Date, nullable=False, default=date.today)
+    content = db.Column(db.Text, nullable=False)
+
+@app.route('/')
+def index():
+    dreams = Dream.query.order_by(Dream.date.desc()).all()
+    return render_template('index.html', dreams=dreams)
+
+@app.route('/add', methods=['GET', 'POST'])
+def add_dream():
+    if request.method == 'POST':
+        title = request.form['title']
+        date_str = request.form['date']
+        content = request.form['content']
+        date = datetime.strptime(date_str, '%Y-%m-%d').date()
+        dream = Dream(title=title, date=date, content=content)
+        db.session.add(dream)
+        db.session.commit()
+        return redirect(url_for('index'))
+    return render_template('add.html')
+
+@app.route('/edit/<int:dream_id>', methods=['GET', 'POST'])
+def edit_dream(dream_id):
+    dream = Dream.query.get_or_404(dream_id)
+    if request.method == 'POST':
+        dream.title = request.form['title']
+        date_str = request.form['date']
+        dream.date = datetime.strptime(date_str, '%Y-%m-%d').date()
+        dream.content = request.form['content']
+        db.session.commit()
+        return redirect(url_for('index'))
+    return render_template('edit.html', dream=dream)
+
+@app.route('/delete/<int:dream_id>', methods=['POST'])
+def delete_dream(dream_id):
+    dream = Dream.query.get_or_404(dream_id)
+    db.session.delete(dream)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy

--- a/templates/add.html
+++ b/templates/add.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+    <title>夢を追加</title>
+</head>
+<body>
+    <h1>夢を追加</h1>
+    <form method="post">
+        <label>タイトル: <input type="text" name="title" required></label><br>
+        <label>日付: <input type="date" name="date" required></label><br>
+        <label>内容:<br>
+            <textarea name="content" rows="5" cols="40" required></textarea>
+        </label><br>
+        <button type="submit">保存</button>
+    </form>
+    <a href="{{ url_for('index') }}">戻る</a>
+</body>
+</html>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+    <title>夢を編集</title>
+</head>
+<body>
+    <h1>夢を編集</h1>
+    <form method="post">
+        <label>タイトル: <input type="text" name="title" value="{{ dream.title }}" required></label><br>
+        <label>日付: <input type="date" name="date" value="{{ dream.date }}" required></label><br>
+        <label>内容:<br>
+            <textarea name="content" rows="5" cols="40" required>{{ dream.content }}</textarea>
+        </label><br>
+        <button type="submit">保存</button>
+    </form>
+    <a href="{{ url_for('index') }}">戻る</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+    <title>夢記録アプリ</title>
+</head>
+<body>
+    <h1>夢記録アプリ</h1>
+    <a href="{{ url_for('add_dream') }}">夢を追加</a>
+    <ul>
+    {% for dream in dreams %}
+        <li>
+            <strong>{{ dream.date }} - {{ dream.title }}</strong><br>
+            {{ dream.content }}<br>
+            <a href="{{ url_for('edit_dream', dream_id=dream.id) }}">編集</a>
+            <form action="{{ url_for('delete_dream', dream_id=dream.id) }}" method="post" style="display:inline;">
+                <button type="submit">削除</button>
+            </form>
+        </li>
+    {% else %}
+        <li>まだ夢がありません。</li>
+    {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- READMEやテンプレートを日本語化
- Dreamモデルの日付のデフォルトを `date.today` に変更

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68420584330883238ecf46f7ea954e6c